### PR TITLE
Start filebeat with -strict.perms=false

### DIFF
--- a/elk_herder/resources/docker-compose.yml
+++ b/elk_herder/resources/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - .:/usr/share/logstash/pipeline/elk-herder
   filebeat:
     image: docker.elastic.co/beats/filebeat:6.3.2
-    entrypoint: ./filebeat -e -c filebeat.yml -d "publish"
+    entrypoint: ./filebeat -strict.perms=false -e -c filebeat.yml -d "publish"
     container_name: filebeat
     depends_on:
       - logstash


### PR DESCRIPTION
Mounting the filebeat config file causes trouble with permission. Since this is just a testing tool, changing 
this to not checking file permissions should be fine.