### PR TITLE
Advanced logstash config, multiline log support, more examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ obj/
 .idea/
 tmp/
 *.pyc
+*~
 
 dist/
 build/

--- a/README.md
+++ b/README.md
@@ -20,15 +20,13 @@ elk-herder knows how to parse this file into both translate these into separate 
 
 # Setup:
 
-Install the Python tool `elk-herder` in py3, e.g. (with conda):
+Install the Python tool `elk-herder` in your py3 environment:
 
-    conda create -q --name elk-herder python=3
-    source activate elk-herder
     pip install -e elk-herder
 
 # Developing groks and other config
 
-Start by executing the docker environment.
+Start by executing the docker environment. From the 'elk-herder' directory run:
 
     elk-herder run
 
@@ -47,6 +45,22 @@ Now (in a third terminal) try to open `./examples/pythonapp.log.config` in a tex
 Finally, try to change the grok. This will take a bit longer, since logstash will restart.
 
 Note that groks can be tested much faster, but this tool provides an integration test for the whole process, where you can change (eventually) other aspects too.
+
+## Advanced configuration
+
+In the common use case, each entry in your 'groks' array maps to a 'match' entry in the resulting logstash configuration. 
+
+However, you may need advanced configuration, such as conditionals directing when the different groks should be used. In this case, you can replace the 'groks' key with a custom 'filter' entry, e.g.:
+
+    description:
+    paths: <list of path globs>
+    filter: 'if [message] =~ /myregex/ {
+      grok {
+          match => {
+            "message" => "foo=%{DATA:bar}"
+          }
+      }'
+    ...
 
 
 # Ensuring all logs are parsed correctly in production

--- a/README.md
+++ b/README.md
@@ -75,4 +75,5 @@ When you encounter such a log, you can add it to the configuration file for the 
 
 * The tool should be able to compare the output of logstash to expected outputs.
 * The interactive test mode should have more user friendly output
+* Allow dynamic configuration for filebeat.yml
 

--- a/elk_herder/resources/filebeat.yml
+++ b/elk_herder/resources/filebeat.yml
@@ -2,6 +2,9 @@ filebeat.prospectors:
 - type: log
   paths:
     - /var/log/elk-herder/filebeat-watches-me.log
+  multiline.pattern: '[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}'
+  multiline.negate: true
+  multiline.match: after
 output.logstash:
   hosts: ["logstash:5044"]
 queue.mem:

--- a/elk_herder/resources/logstash.conf.j2
+++ b/elk_herder/resources/logstash.conf.j2
@@ -3,9 +3,7 @@ input {
         port => "5044"
     }
 }
-filter {
-  {{ grok }}
-}
+{{ filter }}
 output {
     stdout { codec => rubydebug }
 }

--- a/examples/mistral.log.config
+++ b/examples/mistral.log.config
@@ -1,0 +1,54 @@
+description: Logs from Mistral
+paths:
+  - /var/log/mistral/mistral-server.log
+filter: '
+    if [message] =~ /INFO mistral.notifiers.notification_server/ {
+      grok {
+          break_on_match => false
+          match => {
+            "message" => "ex_id=%{DATA:ex_id}, event=%{DATA:event}, timestamp=%{DATA:log_timestamp}"
+          }
+      }
+      if [message] =~ /u''name/ {
+        grok {
+          match => {
+            "message" =>  "u''name'': u''%{DATA:name}''"
+          }
+        }
+      }
+      if [message] =~ /u''workflow_name/ {
+        grok {
+          match => {
+            "message" =>  "u''workflow_name'': u''%{DATA:workflow_name}''"
+          }
+        }
+      }
+      if [message] =~ /u''workflow_id/ {
+        grok {
+          match => {
+            "message" =>  "u''workflow_id'': u''%{DATA:workflow_id}''"
+          }
+        }
+      }
+      if [message] =~ /u''workflow_execution_id/ {
+        grok {
+          match => {
+            "message" =>  "u''workflow_execution_id'': u''%{DATA:workflow_execution_id}''"
+          }
+        }
+      }
+      if [message] =~ /u''trace_tag/ {
+        grok {
+          match => {
+            "message" =>  "u''trace_tag'': u''%{DATA:trace_tag}''"
+          }
+        }
+      }
+    }
+
+'
+timestamp:
+  find: "\\d+-\\d+-\\d+ (\\d+):(\\d+):(\\d+)"
+  replace: "%Y-%m-%d %H:%M:%S"
+###
+2019-01-20 23:30:12.851 932 INFO mistral.engine.engine_server [req-22e7f479-7de9-444a-b545-78f475a2d065 - - - - -]

--- a/examples/stackstorm.log.config
+++ b/examples/stackstorm.log.config
@@ -1,0 +1,83 @@
+description: Logs from Stackstorm
+paths:
+  - /var/log/st2/st2actionrunner.*.log
+filter: '
+    if [message] =~ /liveaction_db/ {
+      grok {
+          break_on_match => false
+          match => {
+            "message" =>  "^%{TIMESTAMP_ISO8601:log_timestamp} %{NUMBER:log_thread} %{WORD:log_level} %{WORD:log_module} \[-\] %{GREEDYDATA:log_data}$"
+          }
+      }
+      grok {
+          match => {
+            "log_data" => "^%{DATA}''status'': ''%{DATA:action_status}''%{DATA}$"
+          }
+      }
+      grok {
+          match => {
+            "log_data" => "^%{DATA}u''trace_tag'': u''%{DATA:trace_tag}''%{DATA}$"
+          }
+      }
+      grok {
+          match => {
+            "log_data" => "%{DATA}''start_timestamp'': ''%{TIMESTAMP_ISO8601:start_timestamp}''%{DATA}"
+          }
+      }
+      grok {
+          match => {
+            "log_data" =>  "%{DATA}''action'': u''%{DATA:action_name}''"
+          }
+      }
+      grok {
+          match => {
+            "log_data" =>  "%{DATA}''id'': ''%{DATA:action_id}''"
+          }
+      }
+
+      if [log_data] =~ /exit_status/ {
+        grok {
+            break_on_match => false
+            match => {
+              "log_data" => "%{DATA}u''exit_status'': %{NUMBER:exit_status}%{DATA}"
+            }
+        }
+      }
+
+      if [log_data] =~ /hostname/ {
+            grok {
+                match => {
+                  "log_data" => "^%{DATA}u''hostname'': u''%{DATA:hostname}'', u''pid'': %{NUMBER:pid}%{DATA}$"
+                }
+            }
+      }
+
+      if [log_data] =~ /u''workflow_name/ {
+        grok {
+            match => {
+              "log_data" =>  "u''workflow_name'': u''%{DATA:workflow_name}''"
+            }
+        }
+      }
+
+      if [log_data] =~ /Launching action execution/ {
+        mutate {
+          add_field => { "action_overall_status" => "STARTED" }
+        }
+      }
+
+      if [log_data] =~ /Liveaction completed/ {
+        mutate {
+          add_field => { "action_overall_status" => "FINISHED" }
+        }
+      }
+
+      mutate { remove_field => ["log_data"] }
+    }
+'
+timestamp:
+  find: "\\d+-\\d+-\\d+ (\\d+):(\\d+):(\\d+)"
+  replace: "%Y-%m-%d %H:%M:%S"
+###
+2019-01-17 18:53:03,292 140128372337712 AUDIT base [-] Liveaction completed
+

--- a/filebeat.yml
+++ b/filebeat.yml
@@ -2,6 +2,9 @@ filebeat.prospectors:
 - type: log
   paths:
     - /var/log/elk-herder/filebeat-watches-me.log
+  multiline.pattern: '[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}'
+  multiline.negate: true
+  multiline.match: after
 output.logstash:
   hosts: ["logstash:5044"]
 queue.mem:


### PR DESCRIPTION
- Allows user to specify an entire 'filter' section instead of individual groks ('grok' key still supported)
- Tweak filebeat.yml to recognize multi-line log entries
- Add generic Stackstorm and Mistral examples